### PR TITLE
Prevent panic when dir {project_name} exists already.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,13 @@ fn main() {
     let project_path = format!("./{}", project_name);
     let src_path = format!("{}/src", project_path);
 
-    create_all(&project_path, false).expect("Failed to create project directory");
-    create_dir(&src_path).expect("Failed to create src directory");
+    if fs::metadata(&project_path).is_ok() {
+        println!("'{}' already exists.", project_name);
+        return;
+    } else {
+        create_all(&project_path, false).expect("Failed to create project directory");
+        create_dir(&src_path).expect("Failed to create src directory");
+    }
 
     let readme_content = templates::default::readme(project_name);
     let cargo_toml_content = templates::default::create_cargo_toml(project_name);


### PR DESCRIPTION
## Issue

1. `cargo run -q` || `cargo run -q -- --name "my-app"`
2. `cargo run -q` || `cargo run -q -- --name "my-app"` (again)
3. 💥 Panic due to dir already existing:
```
thread 'main' panicked at src/main.rs:24:27:
Failed to create src directory: Os { code: 17, kind: AlreadyExists, message: "File exists" }
````

## Fix

Now we check if the given dir already exists and return a message instead of panicking.

1. `cargo run -q` || `cargo run -q -- --name "my-app"`
2. `cargo run -q` || `cargo run -q -- --name "my-app"` (again)
3. 'gpui_app' already exists. || 'my-app' already exists.
