### PR TITLE
v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Nate Butler <iamnbutler@gmail.com>",
     "Zed Industries (@zed-industries)",
 ]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
- Updates default app name: `gpui_app` -> `gpui-app`
- Corrects usage details in README.md