### PR TITLE
add --zed arg to create zed styled projects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,17 @@ struct Args {
     /// Setup your project as a workspace
     #[clap(short, long)]
     workspace: bool,
+    /// Setup a zed style project
+    #[clap(short, long)]
+    zed: bool,
 }
 
 fn copy_and_replace(
     source_dir: &Dir,
     destination_path: &Path,
     project_name: &str,
+    is_zed_style: bool,
+    is_workspace: bool,
 ) -> io::Result<()> {
     const WORD_TO_REPLACE: &str = "PROJECT_NAME";
     let new_destination_path = if destination_path.file_name().unwrap() == WORD_TO_REPLACE {
@@ -32,16 +37,42 @@ fn copy_and_replace(
         let relative_path = entry.path().strip_prefix(source_dir.path()).unwrap();
         let entry_path = new_destination_path.join(relative_path);
         match entry {
-            DirEntry::Dir(dir) => copy_and_replace(&dir, &entry_path, project_name)?,
+            DirEntry::Dir(dir) => {
+                copy_and_replace(&dir, &entry_path, project_name, is_zed_style, is_workspace)?
+            }
             DirEntry::File(file) => {
                 if let Some(content) = file.contents_utf8() {
                     let new_content = content.replace(WORD_TO_REPLACE, project_name);
-                    let new_entry_path = if file.path().file_name().unwrap() == "_Cargo.toml" {
+                    let mut new_entry_path = if file.path().file_name().unwrap() == "_Cargo.toml" {
                         entry_path.with_file_name("Cargo.toml")
                     } else {
                         entry_path.to_owned()
                     };
                     fs::write(&new_entry_path, new_content)?;
+                    let mut content = content.to_string();
+                    if is_zed_style {
+                        match file.path().as_os_str().to_str().unwrap() {
+                            path if path.ends_with("main.rs") => {
+                                new_entry_path.set_file_name(format!("{}.rs", project_name));
+                            }
+                            path if path.ends_with("Cargo.toml") => {
+                                if is_workspace {
+                                    if path.contains("crates") {
+                                        content = content.replace(
+                                            "src/main.rs",
+                                            format!("src/{}.rs", project_name).as_str(),
+                                        );
+                                    }
+                                } else {
+                                    let additional_content = "\n[[bin]]\nname = \"PROJECT_NAME\"\npath = \"src/PROJECT_NAME.rs\"";
+                                    content.push_str(additional_content);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    content = content.replace(WORD_TO_REPLACE, project_name);
+                    fs::write(&new_entry_path, content)?;
                 }
             }
         }
@@ -57,6 +88,7 @@ fn main() -> io::Result<()> {
     let project_name = args.name.unwrap();
     let project_path = Path::new(&project_name);
     let is_workspace = args.workspace;
+    let is_zed_style = args.zed;
 
     if project_path.exists() {
         println!("'{}' already exists.", project_name);
@@ -71,6 +103,8 @@ fn main() -> io::Result<()> {
         },
         project_path,
         &project_name,
+        is_zed_style,
+        is_workspace,
     )?;
 
     println!(


### PR DESCRIPTION
Fixes #13 
This PR enables users to specify arguments to create zed-styled projects.
Usage:
```sh
create-gpui-app --zed
```
This works for all templates (default/workspace).