### PR TITLE
fix directory access from include_dir to enable publishing

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,4 +1,0 @@
-use include_dir::{include_dir, Dir};
-
-pub static DEFAULT_TEMPLATE_DIR: Dir<'_> = include_dir!("src/templates/default");
-pub static WORKSPACE_TEMPLATE_DIR: Dir<'_> = include_dir!("src/templates/workspace");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
-use dirs::{DEFAULT_TEMPLATE_DIR, WORKSPACE_TEMPLATE_DIR};
-use include_dir::{Dir, DirEntry};
+use include_dir::{include_dir, Dir, DirEntry};
 use std::{fs, io, path::Path};
-mod dirs;
+
+static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR");
 
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
@@ -60,9 +60,9 @@ fn main() -> io::Result<()> {
 
     copy_and_replace(
         if is_workspace {
-            &WORKSPACE_TEMPLATE_DIR
+            TEMPLATES_DIR.get_dir("src/templates/workspace").unwrap()
         } else {
-            &DEFAULT_TEMPLATE_DIR
+            TEMPLATES_DIR.get_dir("src/templates/default").unwrap()
         },
         project_path,
         &project_name,


### PR DESCRIPTION
Fix include_str proc macro to include the manifest directory and fix the access inability during publishing.