### PR TITLE
Code cleanup and error fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 use clap::Parser;
 use include_dir::{include_dir, Dir, DirEntry};
-use std::{fs, io, path::Path};
+use std::{
+    fs,
+    io::Result,
+    path::{Path, PathBuf},
+};
 
 static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
 
@@ -19,76 +23,77 @@ struct Args {
 }
 
 fn copy_and_replace(
-    source_dir: &Dir,
-    destination_path: &Path,
-    project_name: &str,
-    is_zed_style: bool,
+    destination_path: &mut PathBuf,
     is_workspace: bool,
-) -> io::Result<()> {
+    is_zed_styled: bool,
+    project_name: &str,
+    source_dir: &Dir,
+) -> Result<()> {
     const WORD_TO_REPLACE: &str = "PROJECT_NAME";
-    let new_destination_path = if destination_path.file_name().unwrap() == WORD_TO_REPLACE {
-        destination_path.with_file_name(project_name)
-    } else {
-        destination_path.to_owned()
+    if destination_path.file_name().unwrap() == WORD_TO_REPLACE {
+        destination_path.set_file_name(project_name)
     };
-    fs::create_dir_all(&new_destination_path)?;
 
+    fs::create_dir_all(&destination_path)?;
     for entry in source_dir.entries() {
         let relative_path = entry.path().strip_prefix(source_dir.path()).unwrap();
-        let entry_path = new_destination_path.join(relative_path);
+        let mut entry_path = destination_path.to_owned().join(relative_path);
         match entry {
-            DirEntry::Dir(dir) => {
-                copy_and_replace(&dir, &entry_path, project_name, is_zed_style, is_workspace)?
-            }
+            DirEntry::Dir(dir) => copy_and_replace(
+                &mut entry_path,
+                is_workspace,
+                is_zed_styled,
+                project_name,
+                &dir,
+            )?,
             DirEntry::File(file) => {
                 if let Some(content) = file.contents_utf8() {
-                    let new_content = content.replace(WORD_TO_REPLACE, project_name);
-                    let mut new_entry_path = if file.path().file_name().unwrap() == "_Cargo.toml" {
-                        entry_path.with_file_name("Cargo.toml")
-                    } else {
-                        entry_path.to_owned()
-                    };
-                    fs::write(&new_entry_path, new_content)?;
-                    let mut content = content.to_string();
-                    if is_zed_style {
-                        match file.path().as_os_str().to_str().unwrap() {
-                            path if path.ends_with("main.rs") => {
-                                new_entry_path.set_file_name(format!("{}.rs", project_name));
-                            }
-                            path if path.ends_with("Cargo.toml") => {
+                    let mut content_string = content.to_string();
+                    match file.path() {
+                        path if path.file_name().unwrap() == "main.rs" => {
+                            if is_zed_styled {
+                                entry_path.set_file_name(format!("{}.rs", project_name))
+                            };
+                        }
+                        path if path.file_name().unwrap() == "_Cargo.toml" => {
+                            if is_zed_styled {
+                                let additional_content = "\n[[bin]]\nname = \"PROJECT_NAME\"\npath = \"src/PROJECT_NAME.rs\"";
                                 if is_workspace {
-                                    if path.contains("crates") {
-                                        content = content.replace(
+                                    if path
+                                        .components()
+                                        .any(|component| component.as_os_str() == "crates")
+                                    {
+                                        content_string = content_string.replace(
                                             "src/main.rs",
                                             format!("src/{}.rs", project_name).as_str(),
                                         );
                                     }
                                 } else {
-                                    let additional_content = "\n[[bin]]\nname = \"PROJECT_NAME\"\npath = \"src/PROJECT_NAME.rs\"";
-                                    content.push_str(additional_content);
+                                    content_string.push_str(additional_content);
                                 }
                             }
-                            _ => {}
+
+                            entry_path.set_file_name("Cargo.toml")
                         }
+                        _ => {}
                     }
-                    content = content.replace(WORD_TO_REPLACE, project_name);
-                    fs::write(&new_entry_path, content)?;
+                    content_string = content_string.replace(WORD_TO_REPLACE, project_name);
+                    fs::write(&entry_path, content_string)?;
                 }
             }
         }
     }
-
     Ok(())
 }
 
 /// Create a new gpui app
-fn main() -> io::Result<()> {
+fn main() -> Result<()> {
     let args = Args::parse();
 
     let project_name = args.name.unwrap();
-    let project_path = Path::new(&project_name);
+    let mut project_path = Path::new(&project_name).to_owned();
     let is_workspace = args.workspace;
-    let is_zed_style = args.zed;
+    let is_zed_styled = args.zed;
 
     if project_path.exists() {
         println!("'{}' already exists.", project_name);
@@ -96,15 +101,15 @@ fn main() -> io::Result<()> {
     }
 
     copy_and_replace(
+        &mut project_path,
+        is_workspace,
+        is_zed_styled,
+        &project_name,
         if is_workspace {
             TEMPLATES_DIR.get_dir("workspace").unwrap()
         } else {
             TEMPLATES_DIR.get_dir("default").unwrap()
         },
-        project_path,
-        &project_name,
-        is_zed_style,
-        is_workspace,
     )?;
 
     println!(


### PR DESCRIPTION
This PR cleans up redundant code and also fixes error when using both `--zed` and `--workspace` flags.