### PR TITLE
feat(cargo): add rustflags to cargo config

### DIFF
--- a/templates/default/.cargo/config.toml
+++ b/templates/default/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=nostart-stop-gc"]

--- a/templates/workspace/.cargo/config.toml
+++ b/templates/workspace/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=nostart-stop-gc"]


### PR DESCRIPTION
I could only make the code work on nightly by applying [this workaround](https://github.com/zed-industries/zed/issues/15902#issuecomment-2273358951), if this is going to be true for a while perhaps we should already include the configuration in the repo.
