### PR TITLE
Revert "feat(cargo): add rustflags to cargo config"

### DIFF
--- a/templates/default/.cargo/config.toml
+++ b/templates/default/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Clink-arg=-z", "-Clink-arg=nostart-stop-gc"]

--- a/templates/workspace/.cargo/config.toml
+++ b/templates/workspace/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Clink-arg=-z", "-Clink-arg=nostart-stop-gc"]


### PR DESCRIPTION
This causes breakages for building on macos, reverting for now. If this is something we need for building on linux we'll need to put it behind a cli argument or something.

Reverts zed-industries/create-gpui-app#27